### PR TITLE
`REVIEW/FEATURE/FRD-16` Split development dependencies into their own requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ $ pip install -e fred
 ```
 * General form: `pip install -e path/to/fred`
 
+For development, we recommend installing the development dependencies:
+* `pip install -r fred/requirements-develop.txt`
+
 To install via pypi (currently unsupported) just use:
 ```
 $ pip install fred-oss

--- a/fred/MANIFEST.in
+++ b/fred/MANIFEST.in
@@ -1,0 +1,3 @@
+include requirements.txt
+include requirements-develop.txt
+include src/main/fred/version

--- a/fred/requirements-develop.txt
+++ b/fred/requirements-develop.txt
@@ -1,0 +1,11 @@
+pycodestyle==2.14.0
+pytest==8.4.1
+coverage==7.10.6
+cookiecutter==2.6.0
+mypy==1.17.1
+mypy-extensions==1.1.0
+typing_extensions==4.15.0
+typed-ast==1.5.5
+scalene==1.5.54
+ipython==9.4.0
+jupyter==1.1.1

--- a/fred/requirements.txt
+++ b/fred/requirements.txt
@@ -1,7 +1,3 @@
 # CLI Tools
 fire==0.7.1
 # Databricks Runtime: 16.4 LTS (Python 3.12.3)
-
-# Additional requirements
-ipython==9.4.0
-jupyter==1.1.1


### PR DESCRIPTION
Reference issue: #16 

Simple PR to split the development dependencies into their own dedicated requirements file. 